### PR TITLE
Auto export script

### DIFF
--- a/.gdignore
+++ b/.gdignore
@@ -1,0 +1,1 @@
+exports/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ export.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+
+exports/

--- a/export.bash
+++ b/export.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+PROJECT_NAME="burger-man"
+
+green=`tput bold setaf 2`
+reset=`tput sgr0`
+
+rm -fr exports
+
+info() {
+    echo "$green$1$reset"
+}
+
+export_as() {
+    info "Exporting $1..."
+    mkdir -p exports/$(dirname $2)
+    godot --export "$1" exports/$2 --no-window 
+
+    if [[ $2 != *.zip ]]; then
+        pushd exports > /dev/null
+        export_dir=$(dirname $2)
+        info "Zipping exports/$export_dir.zip..."
+        zip -r $export_dir.zip $export_dir -9
+        popd > /dev/null
+    fi
+}
+
+export_as HTML5 $PROJECT_NAME-html/index.html
+export_as "Windows Desktop" $PROJECT_NAME-windows/$PROJECT_NAME-windows.exe
+export_as "Linux/X11" $PROJECT_NAME-linux/$PROJECT_NAME-linux.x86_64
+export_as "Mac OSX" $PROJECT_NAME-macos.zip
+
+printf "\nPush to github pages? [y/N] "
+read input
+if [ "$input" = "y" ]; then 
+    current_commit=$(git rev-parse HEAD)
+    cd exports
+    [ ! -d "gh-pages" ] && git worktree add gh-pages
+    cd gh-pages
+    git rm -r .
+    cp ../$PROJECT_NAME-html/* .
+    git add .
+    git commit -m "deploy at $current_commit"
+    git push origin gh-pages
+fi
+

--- a/ziprelease.sh
+++ b/ziprelease.sh
@@ -1,6 +1,0 @@
-cd build
-zip -r burger_man_linux.zip linux
-zip -r burger_man_win.zip win
-zip -r burger_man_html.zip html
-# no mac because mac exports to a zip already
-cd ..


### PR DESCRIPTION
This pr makes a script that replaces the zip_release.sh script by having it export the project into the exports dir as well.

Run `bash export.bash`.